### PR TITLE
Adding Config for Carousel per `position`

### DIFF
--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -8,16 +8,16 @@
             ignoreModules: [],
             global: true,
             top_bar: {enabled: false, ignoreModules: []},
-            bottom_bar: {enabled: false, ignoreModules: []},
             top_left: {enabled: false, ignoreModules: []},
-            bottom_left: {enabled: false, ignoreModules: []},
             top_center: {enabled: false, ignoreModules: []},
-            bottom_center: {enabled: false, ignoreModules: []},
             top_right: {enabled: false, ignoreModules: []},
-            bottom_right: {enabled: false, ignoreModules: []},
             upper_third: {enabled: false, ignoreModules: []},
             middle_center: {enabled: false, ignoreModules: []},
-            lower_third: {enabled: false, ignoreModules: []}
+            lower_third: {enabled: false, ignoreModules: []},
+            bottom_left: {enabled: false, ignoreModules: []},
+            bottom_center: {enabled: false, ignoreModules: []},
+            bottom_right: {enabled: false, ignoreModules: []},
+            bottom_bar: {enabled: false, ignoreModules: []}
         },
 
         notificationReceived: function (notification) {

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -27,17 +27,38 @@
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
-                this.modules = MM.getModules().exceptModule(this).filter(function (module) {
-                    return this.config.ignoreModules.indexOf(module.name) === -1;
-                }, this);
+                if (this.config.global === true) {
+                    this.modules = MM.getModules().exceptModule(this).filter(function (module) {
+                        return this.config.ignoreModules.indexOf(module.name) === -1;
+                    }, this);
 
-                this.modules.currentIndex = 0;
-                for (i = 1; i < this.modules.length; i += 1) {
-                    this.modules[i].hide();
+                    this.modules.currentIndex = 0;
+                    for (i = 1; i < this.modules.length; i += 1) {
+                        this.modules[i].hide();
+                    }
+
+                    // We set a timer to cause the page transitions
+                    this.transitionTimer = setInterval(this.moduleTransition.bind(this.modules), this.config.transitionInterval);
+                } else {
+                    var modules;
+                    for (var position in positions) {
+                        if (!positions.hasOwnProperty(position)) continue;
+                        if (!this.config.hasOwnProperty(position)) continue;
+                        if (this.config[position].enabled === true) {
+                            modules = MM.getModules().exceptModule(this).filter(function (module) {
+                                return ((this.config[position].ignoreModules.indexOf(module.name) === -1) && (module.data.position === position));
+                            }, this);
+
+                            modules.currentIndex = 0;
+                            for (i = 1; i < modules.length; i += 1) {
+                                modules[i].hide();
+                            }
+
+                            // We set a timer to cause the page transitions
+                            this.transitionTimer = setInterval(this.moduleTransition.bind(modules), this.config.transitionInterval);
+                        }
+                    }
                 }
-
-                // We set a timer to cause the page transitions
-                this.transitionTimer = setInterval(this.moduleTransition.bind(this.modules), this.config.transitionInterval);
             }
         },
 

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -51,7 +51,7 @@
                 }
             }, this);
             modules.currentIndex = 0;
-            for (i = 1; i < this.modules.length; i += 1) {
+            for (i = 1; i < modules.length; i += 1) {
                 modules[i].hide();
             }
 

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -22,25 +22,25 @@
 
         notificationReceived: function (notification) {
             var positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
-
+            var position;
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
                 if (this.config.global === true) {
-                    this.setUpTransitionTimers(true, null, null);
+                    this.setUpTransitionTimers(null);
                 } else {
-                    for (var position in positions) {
+                    for (position in positions) {
                         if (!positions.hasOwnProperty(position)) continue;
                         if (!this.config.hasOwnProperty(positions[position])) continue;
                         if (this.config[positions[position]].enabled === true) {
-                            this.setUpTransitionTimers(false, positions[position]);
+                            this.setUpTransitionTimers(positions[position]);
                         }
                     }
                 }
             }
         },
 
-        setUpTransitionTimers: function(global, positionIndex) {
+        setUpTransitionTimers: function(positionIndex) {
             var i;
             var modules;
             modules = MM.getModules().exceptModule(this).filter(function (module) {

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -21,8 +21,7 @@
         },
 
         notificationReceived: function (notification) {
-            var positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
-            var position;
+            var position, positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
@@ -30,8 +29,8 @@
                     this.setUpTransitionTimers(null);
                 } else {
                     for (position in positions) {
-                        if (!positions.hasOwnProperty(position)) continue;
-                        if (!this.config.hasOwnProperty(positions[position])) continue;
+                        if (!positions.hasOwnProperty(position)) {continue;}
+                        if (!this.config.hasOwnProperty(positions[position])) {continue;}
                         if (this.config[positions[position]].enabled === true) {
                             this.setUpTransitionTimers(positions[position]);
                         }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -5,21 +5,30 @@
     Module.register('MMM-Carousel', {
         defaults: {
             transitionInterval: 10000,
-            ignoreModules: []
+            ignoreModules: [],
+            global: true,
+            top_bar: {enabled: false, ignoreModules: []},
+            bottom_bar: {enabled: false, ignoreModules: []},
+            top_left: {enabled: false, ignoreModules: []},
+            bottom_left: {enabled: false, ignoreModules: []},
+            top_center: {enabled: false, ignoreModules: []},
+            bottom_center: {enabled: false, ignoreModules: []},
+            top_right: {enabled: false, ignoreModules: []},
+            bottom_right: {enabled: false, ignoreModules: []},
+            upper_third: {enabled: false, ignoreModules: []},
+            middle_center: {enabled: false, ignoreModules: []},
+            lower_third: {enabled: false, ignoreModules: []}
         },
 
         notificationReceived: function (notification) {
             var i;
+            var positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
 
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
                 this.modules = MM.getModules().exceptModule(this).filter(function (module) {
-                    if (this.config.ignoreModules.indexOf(module.name) === -1) {
-                        return true;
-                    }
-
-                    return false;
+                    return this.config.ignoreModules.indexOf(module.name) === -1;
                 }, this);
 
                 this.currentIndex = 0;
@@ -28,26 +37,26 @@
                 }
 
                 // We set a timer to cause the page transitions
-                this.transitionTimer = setInterval(this.moduleTransition.bind(this), this.config.transitionInterval);
+                this.transitionTimer = setInterval(this.moduleTransition(this.modules), this.config.transitionInterval);
             }
         },
 
-        moduleTransition: function () {
+        moduleTransition: function (modules) {
             var i;
 
             // Update the current index
             this.currentIndex += 1;
-            if (this.currentIndex >= this.modules.length) {
+            if (this.currentIndex >= modules.length) {
                 this.currentIndex = 0;
             }
 
-            for (i = 0; i < this.modules.length; i += 1) {
+            for (i = 0; i < modules.length; i += 1) {
                 // There is currently no easy way to discover whether a module is ALREADY shown/hidden
                 // In testing, calling show/hide twice seems to cause no issues
                 if (i === this.currentIndex) {
-                    this.modules[i].show();
+                    modules[i].show();
                 } else {
-                    this.modules[i].hide();
+                    modules[i].hide();
                 }
             }
         }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -21,29 +21,42 @@
         },
 
         notificationReceived: function (notification) {
-            var i;
             var positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
-            var modules;
 
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
-                    modules = MM.getModules().exceptModule(this).filter(function (module) {
-                        if (this.config.global === true) {
-                            return this.config.ignoreModules.indexOf(module.name) === -1;
-                        } else {
-                            return ((this.config[positions[position]].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positions[position]));
-
+                if (this.config.global === true) {
+                    this.setUpTransitionTimers(true, null, null);
+                } else {
+                    for (var position in positions) {
+                        if (!positions.hasOwnProperty(position)) continue;
+                        if (!this.config.hasOwnProperty(positions[position])) continue;
+                        if (this.config[positions[position]].enabled === true) {
+                            this.setUpTransitionTimers(false, position[position]);
                         }
-                    }, this);
-                    modules.currentIndex = 0;
-                    for (i = 1; i < this.modules.length; i += 1) {
-                        modules[i].hide();
                     }
-
-                    // We set a timer to cause the page transitions
-                    this.transitionTimer = setInterval(this.moduleTransition.bind(modules), this.config.transitionInterval);
+                }
             }
+        },
+
+        setUpTransitionTimers: function(global, positionIndex) {
+            var i;
+            var modules;
+            modules = MM.getModules().exceptModule(this).filter(function (module) {
+                if (this.config.global === true) {
+                    return this.config.ignoreModules.indexOf(module.name) === -1;
+                } else {
+                    return ((this.config[positionIndex].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positionIndex));
+                }
+            }, this);
+            modules.currentIndex = 0;
+            for (i = 1; i < this.modules.length; i += 1) {
+                modules[i].hide();
+            }
+
+            // We set a timer to cause the page transitions
+            this.transitionTimer = setInterval(this.moduleTransition.bind(modules), this.config.transitionInterval);
         },
 
         moduleTransition: function () {

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -21,18 +21,16 @@
         },
 
         notificationReceived: function (notification) {
-            var position, positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
+            var i, position, positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
                 if (this.config.global === true) {
                     this.setUpTransitionTimers(null);
                 } else {
-                    for (position in positions) {
-                        if (!positions.hasOwnProperty(position)) { continue; }
-                        if (!this.config.hasOwnProperty(positions[position])) { continue; }
-                        if (this.config[positions[position]].enabled === true) {
-                            this.setUpTransitionTimers(positions[position]);
+                    for (i=0;i < positions.length; i++) {
+                        if (this.config[positions[i]].enabled === true) {
+                            this.setUpTransitionTimers(positions[i]);
                         }
                     }
                 }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -29,8 +29,8 @@
                     this.setUpTransitionTimers(null);
                 } else {
                     for (position in positions) {
-                        if (!positions.hasOwnProperty(position)) {continue;}
-                        if (!this.config.hasOwnProperty(positions[position])) {continue;}
+                        if (!positions.hasOwnProperty(position)) { continue; }
+                        if (!this.config.hasOwnProperty(positions[position])) { continue; }
                         if (this.config[positions[position]].enabled === true) {
                             this.setUpTransitionTimers(positions[position]);
                         }
@@ -39,15 +39,13 @@
             }
         },
 
-        setUpTransitionTimers: function(positionIndex) {
-            var i;
-            var modules;
+        setUpTransitionTimers: function (positionIndex) {
+            var i, modules;
             modules = MM.getModules().exceptModule(this).filter(function (module) {
                 if (this.config.global === true) {
                     return this.config.ignoreModules.indexOf(module.name) === -1;
-                } else {
-                    return ((this.config[positionIndex].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positionIndex));
                 }
+                return ((this.config[positionIndex].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positionIndex));
             }, this);
             modules.currentIndex = 0;
             for (i = 1; i < modules.length; i += 1) {

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -23,42 +23,26 @@
         notificationReceived: function (notification) {
             var i;
             var positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
+            var modules;
 
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
-                if (this.config.global === true) {
-                    this.modules = MM.getModules().exceptModule(this).filter(function (module) {
-                        return this.config.ignoreModules.indexOf(module.name) === -1;
-                    }, this);
+                    modules = MM.getModules().exceptModule(this).filter(function (module) {
+                        if (this.config.global === true) {
+                            return this.config.ignoreModules.indexOf(module.name) === -1;
+                        } else {
+                            return ((this.config[positions[position]].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positions[position]));
 
-                    this.modules.currentIndex = 0;
+                        }
+                    }, this);
+                    modules.currentIndex = 0;
                     for (i = 1; i < this.modules.length; i += 1) {
-                        this.modules[i].hide();
+                        modules[i].hide();
                     }
 
                     // We set a timer to cause the page transitions
-                    this.transitionTimer = setInterval(this.moduleTransition.bind(this.modules), this.config.transitionInterval);
-                } else {
-                    var modules;
-                    for (var position in positions) {
-                        if (!positions.hasOwnProperty(position)) continue;
-                        if (!this.config.hasOwnProperty(positions[position])) continue;
-                        if (this.config[positions[position]].enabled === true) {
-                            modules = MM.getModules().exceptModule(this).filter(function (module) {
-                                return ((this.config[positions[position]].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positions[position]));
-                            }, this);
-
-                            modules.currentIndex = 0;
-                            for (i = 1; i < modules.length; i += 1) {
-                                modules[i].hide();
-                            }
-
-                            // We set a timer to cause the page transitions
-                            this.transitionTimer = setInterval(this.moduleTransition.bind(modules), this.config.transitionInterval);
-                        }
-                    }
-                }
+                    this.transitionTimer = setInterval(this.moduleTransition.bind(modules), this.config.transitionInterval);
             }
         },
 

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -28,7 +28,7 @@
                 if (this.config.global === true) {
                     this.setUpTransitionTimers(null);
                 } else {
-                    for (position=0;position < positions.length; position++) {
+                    for (position = 0; position < positions.length; position += 1) {
                         if (this.config[positions[position]].enabled === true) {
                             this.setUpTransitionTimers(positions[position]);
                         }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -37,26 +37,26 @@
                 }
 
                 // We set a timer to cause the page transitions
-                this.transitionTimer = setInterval(this.moduleTransition(this.modules), this.config.transitionInterval);
+                this.transitionTimer = setInterval(this.moduleTransition.bind(this.modules), this.config.transitionInterval);
             }
         },
 
-        moduleTransition: function (modules) {
+        moduleTransition: function () {
             var i;
 
             // Update the current index
             this.currentIndex += 1;
-            if (this.currentIndex >= modules.length) {
+            if (this.currentIndex >= this.length) {
                 this.currentIndex = 0;
             }
 
-            for (i = 0; i < modules.length; i += 1) {
+            for (i = 0; i < this.length; i += 1) {
                 // There is currently no easy way to discover whether a module is ALREADY shown/hidden
                 // In testing, calling show/hide twice seems to cause no issues
                 if (i === this.currentIndex) {
-                    modules[i].show();
+                    this[i].show();
                 } else {
-                    modules[i].hide();
+                    this[i].hide();
                 }
             }
         }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -75,9 +75,9 @@
                 // There is currently no easy way to discover whether a module is ALREADY shown/hidden
                 // In testing, calling show/hide twice seems to cause no issues
                 if (i === this.currentIndex) {
-                    this[i].show();
+                    this[i].show(1500);
                 } else {
-                    this[i].hide();
+                    this[i].hide(0);
                 }
             }
         }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -33,7 +33,7 @@
                         if (!positions.hasOwnProperty(position)) continue;
                         if (!this.config.hasOwnProperty(positions[position])) continue;
                         if (this.config[positions[position]].enabled === true) {
-                            this.setUpTransitionTimers(false, position[position]);
+                            this.setUpTransitionTimers(false, positions[position]);
                         }
                     }
                 }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -21,16 +21,16 @@
         },
 
         notificationReceived: function (notification) {
-            var i, position, positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
+            var position, positions = ['top_bar', 'bottom_bar', 'top_left', 'bottom_left', 'top_center', 'bottom_center', 'top_right', 'bottom_right', 'upper_third', 'middle_center', 'lower_third'];
             if (notification === 'DOM_OBJECTS_CREATED') {
                 // Initially, all modules are hidden except the first and any ignored modules
                 // We start by getting a list of all of the modules in the transition cycle
                 if (this.config.global === true) {
                     this.setUpTransitionTimers(null);
                 } else {
-                    for (i=0;i < positions.length; i++) {
-                        if (this.config[positions[i]].enabled === true) {
-                            this.setUpTransitionTimers(positions[i]);
+                    for (position=0;position < positions.length; position++) {
+                        if (this.config[positions[position]].enabled === true) {
+                            this.setUpTransitionTimers(positions[position]);
                         }
                     }
                 }

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -43,10 +43,10 @@
                     var modules;
                     for (var position in positions) {
                         if (!positions.hasOwnProperty(position)) continue;
-                        if (!this.config.hasOwnProperty(position)) continue;
-                        if (this.config[position].enabled === true) {
+                        if (!this.config.hasOwnProperty(positions[position])) continue;
+                        if (this.config[positions[position]].enabled === true) {
                             modules = MM.getModules().exceptModule(this).filter(function (module) {
-                                return ((this.config[position].ignoreModules.indexOf(module.name) === -1) && (module.data.position === position));
+                                return ((this.config[positions[position]].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positions[position]));
                             }, this);
 
                             modules.currentIndex = 0;

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -31,7 +31,7 @@
                     return this.config.ignoreModules.indexOf(module.name) === -1;
                 }, this);
 
-                this.currentIndex = 0;
+                this.modules.currentIndex = 0;
                 for (i = 1; i < this.modules.length; i += 1) {
                     this.modules[i].hide();
                 }

--- a/README.md
+++ b/README.md
@@ -27,12 +27,76 @@ Note that a `position` setting is not required.
 A typical config file is also provided: [config.sample.js](config.sample.js)
 
 ### Configuration options
-#### ignoreModules
-Type: `String array` Default value: `[]`
+The following properties can be configured:
 
-A list of module names whom should not be considered as part of the carousel. For example, the `alert` module should be able to display a notification at any time, by ignoring it we can prevent the plugin from hiding any notifications.
+<table width="100%">
+	<!-- why, markdown... -->
+	<thead>
+		<tr>
+			<th>Option</th>
+			<th width="100%">Description</th>
+		</tr>
+	<thead>
+	<tbody>
+		<tr>
+			<td><code>transitionInterval</code></td>
+			<td>The number of milliseconds to display each module for.
+				<br> <br> This value is <b>OPTIONAL</b>
+				<br><b>Possible values:</b> Any valid <code>int</code>
+                <br><b>Default value:</b> <code>10000</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>ignoreModules</code></td>
+			<td>A list of module names whom should not be considered as part of the carousel. For example, the `alert` module should be able to display a notification at any time, by ignoring it we can prevent the plugin from hiding any notifications. <b> NOTE: is only used when <code>global</code> is <code>true</code></b>.
+				<br> <br> This value is <b>OPTIONAL</b>
+				<br><b>Possible values:</b> <code>String array</code>
+                <br><b>Default value:</b> <code>[]</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>global</code></td>
+			<td>When true all modules regardless of position are rotated.  When false each <code>position</code> is rotated independantly according to the config for that position. (see below).
+				<br> <br> This value is <b>OPTIONAL</b>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+                <br><b>Default value:</b> <code>true</code>
+			</td>
+		</tr>
+		<tr>
+			<td>
+			    <code>top_bar</code>
+			    <br><code>top_left</code>
+			    <br><code>top_center</code>
+			    <br><code>top_right</code>
+			    <br><code>upper_third</code>
+			    <br><code>middle_center</code>
+			    <br><code>lower_third</code>
+			    <br><code>bottom_left</code>
+			    <br><code>bottom_center</code>
+			    <br><code>Bottom_right</code>
+			    <br><code>bottom_bar</code>
+			</td>
+			<td>Determines if this position should be rotated and which modules in this position should be ignored and always displayed.  <b>NOTE: is only used when <code>global</code> is <code>false</code></b>.
+				<br> <br> This value is <b>OPTIONAL</b>
+				<br><b>Possible values:</b> Object with keys;
+				<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <code>enabled</code>, a boolean to rotate this position or not,
+				<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <code>ignoredModules</code>, a <code>String array</code> of modules nemes to ignore.
+                <br><b>Default value:</b> <code>{enabled: false, ignoreModules: []}</code>
+			</td>
+		</tr>
+	</tbody>
+</table>
 
-#### transitionInterval
-Type: `Integer` Default value: `10000`
-
-The number of milliseconds to display each module for.
+#### Example
+```json
+{
+    module: 'MMM-Carousel',
+    config: {
+        transitionInterval: 10000,
+        ignoreModules: [],
+        global: false,
+        top_left: {enabled: true, ignoreModules: []},
+        top_right: {enabled: true, ignoreModules: ['currentweather']}
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ The following properties can be configured:
 			    <br><code>lower_third</code>
 			    <br><code>bottom_left</code>
 			    <br><code>bottom_center</code>
-			    <br><code>Bottom_right</code>
+			    <br><code>bottom_right</code>
 			    <br><code>bottom_bar</code>
 			</td>
-			<td>Determines if this position should be rotated and which modules in this position should be ignored and always displayed.  <b>NOTE: is only used when <code>global</code> is <code>false</code></b>.
+			<td>Determines if this position should be rotated and which modules in this position should be ignored.  <b>NOTE: is only used when <code>global</code> is <code>false</code></b>.
 				<br> <br> This value is <b>OPTIONAL</b>
 				<br><b>Possible values:</b> Object with keys;
 				<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <code>enabled</code>, a boolean to rotate this position or not,
-				<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <code>ignoredModules</code>, a <code>String array</code> of modules nemes to ignore.
+				<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <code>ignoredModules</code>, a <code>String array</code> of modules names to ignore.
                 <br><b>Default value:</b> <code>{enabled: false, ignoreModules: []}</code>
 			</td>
 		</tr>
@@ -88,15 +88,15 @@ The following properties can be configured:
 </table>
 
 #### Example
-```json
-{
-    module: 'MMM-Carousel',
-    config: {
-        transitionInterval: 10000,
-        ignoreModules: [],
-        global: false,
-        top_left: {enabled: true, ignoreModules: []},
-        top_right: {enabled: true, ignoreModules: ['currentweather']}
+```javascript
+    {
+        module: 'MMM-Carousel',
+        config: {
+            transitionInterval: 10000,
+            ignoreModules: [],
+            global: false,
+            top_left: {enabled: true, ignoreModules: []},
+            top_right: {enabled: true, ignoreModules: ['currentweather']}
+        }
     }
-}
 ```

--- a/test.js
+++ b/test.js
@@ -27,6 +27,8 @@
             };
 
             moduleObject = moduleObjectArgument;
+
+            moduleObject.currentIndex = 0;
         }
     };
 
@@ -74,7 +76,7 @@
 
     exports.moduleTransitionCorrectlyUpdatesHiddenStatus = function (test) {
         initialiseModule();
-        moduleObject.moduleTransition.bind(modulesList);
+        moduleObject.moduleTransition();
 
         test.expect(4);
         test.ok(!modulesList[0].hidden, "The ignoreModules option should cause the first module to be ignored.");

--- a/test.js
+++ b/test.js
@@ -22,7 +22,8 @@
             // We add the config option to the moduleObject, allowing us to test for these specific values later
             moduleObjectArgument.config = {
                 transitionInterval: 12345,
-                ignoreModules: [ '0' ]
+                ignoreModules: [ '0' ],
+                global: true
             };
 
             moduleObject = moduleObjectArgument;

--- a/test.js
+++ b/test.js
@@ -76,7 +76,7 @@
 
     exports.moduleTransitionCorrectlyUpdatesHiddenStatus = function (test) {
         initialiseModule();
-        moduleObject.moduleTransition();
+        moduleObject.moduleTransition(modulesList);
 
         test.expect(4);
         test.ok(!modulesList[0].hidden, "The ignoreModules option should cause the first module to be ignored.");

--- a/test.js
+++ b/test.js
@@ -74,7 +74,7 @@
 
     exports.moduleTransitionCorrectlyUpdatesHiddenStatus = function (test) {
         initialiseModule();
-        moduleObject.moduleTransition();
+        moduleObject.moduleTransition.bind(modulesList);
 
         test.expect(4);
         test.ok(!modulesList[0].hidden, "The ignoreModules option should cause the first module to be ignored.");

--- a/test.js
+++ b/test.js
@@ -27,8 +27,6 @@
             };
 
             moduleObject = moduleObjectArgument;
-
-            moduleObject.currentIndex = 0;
         }
     };
 
@@ -76,7 +74,7 @@
 
     exports.moduleTransitionCorrectlyUpdatesHiddenStatus = function (test) {
         initialiseModule();
-        moduleObject.moduleTransition(modulesList);
+        moduleObject.moduleTransition();
 
         test.expect(4);
         test.ok(!modulesList[0].hidden, "The ignoreModules option should cause the first module to be ignored.");


### PR DESCRIPTION
In using magic mirror, I have plenty of space to spread my modules out, but I still have overall space issues.  What I need to be able to do is carousel each position independently, rather than globally doing them all.

To that end I have extended `MMM-Carousel` to include configuration for each `position`.  The whole change is predicated by a new config flag `global` which defaults to `true`, so default behaviour is unchanged.  

Please see the changes in the `README.md` for details of how the config works.