### PR TITLE
'carouselID' config values auto-replaces module name if found

### DIFF
--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -88,7 +88,6 @@
 				var moduleName = this[i].name;
 				if (this[i].config.carouselID !== undefined)
 					moduleName = this[i].config.carouselID;
-				console.log("i " + i + " = " + this[i].name + ", " + moduleName);
                 if (((this.slides === undefined) && (i === this.currentIndex)) || ((this.slides !== undefined) && (this.slides[this.currentIndex].indexOf(moduleName) !== -1))) {
                     this[i].show(1500);
                 } else {

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -42,11 +42,16 @@
 
         setUpTransitionTimers: function (positionIndex) {
             var modules, timer = this.config.transitionInterval;
+
             modules = MM.getModules().exceptModule(this).filter(function (module) {
-                if (positionIndex === null) {
-                    return this.config.ignoreModules.indexOf(module.name) === -1;
+				// get module name, then if carouselID exists use that instead
+				var moduleName = module.name;
+				if (module.config.carouselID !== undefined)
+					moduleName = module.config.carouselID;
+				if (positionIndex === null) {
+                    return this.config.ignoreModules.indexOf(moduleName) === -1;
                 }
-                return ((this.config[positionIndex].ignoreModules.indexOf(module.name) === -1) && (module.data.position === positionIndex));
+                return ((this.config[positionIndex].ignoreModules.indexOf(moduleName) === -1) && (module.data.position === positionIndex));
             }, this);
 
             if (this.config.mode === 'slides') {
@@ -78,8 +83,13 @@
 
             for (i = 0; i < this.length; i += 1) {
                 // There is currently no easy way to discover whether a module is ALREADY shown/hidden
-                // In testing, calling show/hide twice seems to cause no issues
-                if (((this.slides === undefined) && (i === this.currentIndex)) || ((this.slides !== undefined) && (this.slides[this.currentIndex].indexOf(this[i].name) !== -1))) {
+                // In testing, calling show/hide twice seems to cause no issues				
+				// get module name, then if carouselID exists use that instead				
+				var moduleName = this[i].name;
+				if (this[i].config.carouselID !== undefined)
+					moduleName = this[i].config.carouselID;
+				console.log("i " + i + " = " + this[i].name + ", " + moduleName);
+                if (((this.slides === undefined) && (i === this.currentIndex)) || ((this.slides !== undefined) && (this.slides[this.currentIndex].indexOf(moduleName) !== -1))) {
                     this[i].show(1500);
                 } else {
                     this[i].hide(0);

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ var config = {
 
 Note that a `position` setting is not required.
 
+**NOTE:** For the other modules in the config.js file, the name of any instance of a module is automatically it's module name, meaning if you have two instances of the 'clock' module in your config.js file than each is named 'clock' as far as the MMM-Carousel code is concerned. This can cause obvious conflicts if you want to ignore certain modules or create slides involving multiple instances of the same module type. To overcome this you can add a 'carouselID' value to any module's config options. If this value is found than it will replace the module name as far as it is handled by MMM-Carousel.
+
 ### Configuration options
 The following properties can be configured:
 


### PR DESCRIPTION
This prevents conflicts from multiple instances of the same module type, allowing more complex creation of slides and position groups.